### PR TITLE
Additiona key proofs for Rocky Linux 8/9

### DIFF
--- a/registry/0675BD19F4FFE3AD0B2D6FEBADA2860895AE3D91.json
+++ b/registry/0675BD19F4FFE3AD0B2D6FEBADA2860895AE3D91.json
@@ -24,6 +24,12 @@
       "comment": "Listed with other Project Keys and instructions for verifying key fingerprints: Rocky Linux 9 (Testing)",
       "url": "https://web.archive.org/web/20240331063950/https://rockylinux.org/keys/",
       "type": "role"
+    },
+    {
+      "date": "2025-03-17",
+      "comment": "Listed in BaseOS source package: rocky-release-9.5-1.2.el9.src.rpm (sha256:975db6f5e89fc5538a5a4b296d66d3fe1fe6a0f1e557dfb95183dec148d8ca79)",
+      "url": "https://dl.rockylinux.org/pub/rocky/9/BaseOS/source/tree/Packages/r/rocky-release-9.5-1.2.el9.src.rpm",
+      "type": "role"
     }
   ],
   "tags": [

--- a/registry/091A44047C3D8B7A331F5E185489E42BBBE2C108.json
+++ b/registry/091A44047C3D8B7A331F5E185489E42BBBE2C108.json
@@ -24,6 +24,12 @@
       "comment": "Listed with other Project Keys and instructions for verifying key fingerprints: Rocky Linux 8 (Testing)",
       "url": "https://web.archive.org/web/20240331063950/https://rockylinux.org/keys/",
       "type": "role"
+    },
+    {
+      "date": "2025-03-17",
+      "comment": "Listed in BaseOS source package: rocky-release-8.10-1.9.el8.src.rpm (sha256:487c7bd08dcac094bea86fa4c9d74569ef29edc393344e2ddd9c5c590652e98c)",
+      "url": "https://dl.rockylinux.org/pub/rocky/8/BaseOS/source/tree/Packages/r/rocky-release-8.10-1.9.el8.src.rpm",
+      "type": "role"
     }
   ],
   "tags": [

--- a/registry/21CB256AE16FC54C6E652949702D426D350D275D.json
+++ b/registry/21CB256AE16FC54C6E652949702D426D350D275D.json
@@ -24,6 +24,12 @@
       "comment": "Listed with other Project Keys and instructions for verifying key fingerprints: Rocky Linux 9 (Release)",
       "url": "https://web.archive.org/web/20240331063950/https://rockylinux.org/keys/",
       "type": "role"
+    },
+    {
+      "date": "2025-03-17",
+      "comment": "Listed in BaseOS source package: rocky-release-9.5-1.2.el9.src.rpm (sha256:975db6f5e89fc5538a5a4b296d66d3fe1fe6a0f1e557dfb95183dec148d8ca79)",
+      "url": "https://dl.rockylinux.org/pub/rocky/9/BaseOS/source/tree/Packages/r/rocky-release-9.5-1.2.el9.src.rpm",
+      "type": "role"
     }
   ],
   "tags": [

--- a/registry/7051C470A929F454CEBE37B715AF5DAC6D745A60.json
+++ b/registry/7051C470A929F454CEBE37B715AF5DAC6D745A60.json
@@ -24,6 +24,12 @@
       "comment": "Listed with other Project Keys and instructions for verifying key fingerprints: Rocky Linux 8 (Release)",
       "url": "https://web.archive.org/web/20240331063950/https://rockylinux.org/keys/",
       "type": "role"
+    },
+    {
+      "date": "2025-03-17",
+      "comment": "Listed in BaseOS source package: rocky-release-8.10-1.9.el8.src.rpm (sha256:487c7bd08dcac094bea86fa4c9d74569ef29edc393344e2ddd9c5c590652e98c)",
+      "url": "https://dl.rockylinux.org/pub/rocky/8/BaseOS/source/tree/Packages/r/rocky-release-8.10-1.9.el8.src.rpm",
+      "type": "role"
     }
   ],
   "tags": [


### PR DESCRIPTION
Adds packaged references to Rocky Linux 8 & 9:
- **rocky-release-8.10-1.9.el8.src.rpm** (`sha256:487c7bd08dcac094bea86fa4c9d74569ef29edc393344e2ddd9c5c590652e98c`)
  - RPM-GPG-KEY-rockyofficial (15AF 5DAC 6D74 5A60)
  - RPM-GPG-KEY-rockytesting (5489 E42B BBE2 C108)
- **rocky-release-9.5-1.2.el9.src.rpm** (`sha256:975db6f5e89fc5538a5a4b296d66d3fe1fe6a0f1e557dfb95183dec148d8ca79`)
  - RPM-GPG-KEY-Rocky-9 (702D 426D 350D 275D)
  - RPM-GPG-KEY-Rocky-9-Testing (ADA2 8608 95AE 3D91)
