### PR TITLE
Updated key proofs for Rocky Linux: GPG Key Info page (/keys)

### DIFF
--- a/registry/0675BD19F4FFE3AD0B2D6FEBADA2860895AE3D91.json
+++ b/registry/0675BD19F4FFE3AD0B2D6FEBADA2860895AE3D91.json
@@ -22,7 +22,7 @@
     {
       "date": "2024-03-31",
       "comment": "Listed with other Project Keys and instructions for verifying key fingerprints: Rocky Linux 9 (Testing)",
-      "url": "https://web.archive.org/web/20240331063950/https://rockylinux.org/keys/",
+      "url": ["https://github.com/rocky-linux/rockylinux.org/blob/develop/resources/gpg-key-info.md", "https://web.archive.org/web/20240331063950/https://rockylinux.org/keys/", "https://rockylinux.org/resources/gpg-key-info", "https://rockylinux.org/keys"],
       "type": "role"
     },
     {

--- a/registry/091A44047C3D8B7A331F5E185489E42BBBE2C108.json
+++ b/registry/091A44047C3D8B7A331F5E185489E42BBBE2C108.json
@@ -22,7 +22,7 @@
     {
       "date": "2024-03-31",
       "comment": "Listed with other Project Keys and instructions for verifying key fingerprints: Rocky Linux 8 (Testing)",
-      "url": "https://web.archive.org/web/20240331063950/https://rockylinux.org/keys/",
+      "url": ["https://github.com/rocky-linux/rockylinux.org/blob/develop/resources/gpg-key-info.md", "https://web.archive.org/web/20240331063950/https://rockylinux.org/keys/", "https://rockylinux.org/resources/gpg-key-info", "https://rockylinux.org/keys"],
       "type": "role"
     },
     {

--- a/registry/21CB256AE16FC54C6E652949702D426D350D275D.json
+++ b/registry/21CB256AE16FC54C6E652949702D426D350D275D.json
@@ -22,7 +22,7 @@
     {
       "date": "2023-01-17",
       "comment": "Listed with other Project Keys and instructions for verifying key fingerprints: Rocky Linux 9 (Release)",
-      "url": "https://web.archive.org/web/20240331063950/https://rockylinux.org/keys/",
+      "url": ["https://github.com/rocky-linux/rockylinux.org/blob/develop/resources/gpg-key-info.md", "https://web.archive.org/web/20240331063950/https://rockylinux.org/keys/", "https://rockylinux.org/resources/gpg-key-info", "https://rockylinux.org/keys"],
       "type": "role"
     },
     {

--- a/registry/7051C470A929F454CEBE37B715AF5DAC6D745A60.json
+++ b/registry/7051C470A929F454CEBE37B715AF5DAC6D745A60.json
@@ -22,7 +22,7 @@
     {
       "date": "2024-03-31",
       "comment": "Listed with other Project Keys and instructions for verifying key fingerprints: Rocky Linux 8 (Release)",
-      "url": "https://web.archive.org/web/20240331063950/https://rockylinux.org/keys/",
+      "url": ["https://github.com/rocky-linux/rockylinux.org/blob/develop/resources/gpg-key-info.md", "https://web.archive.org/web/20240331063950/https://rockylinux.org/keys/", "https://rockylinux.org/resources/gpg-key-info", "https://rockylinux.org/keys"],
       "type": "role"
     },
     {

--- a/registry/BFC3D8F20D15F4FD46281D7FAA650F52D6C094FA.json
+++ b/registry/BFC3D8F20D15F4FD46281D7FAA650F52D6C094FA.json
@@ -22,7 +22,7 @@
     {
       "date": "2024-03-31",
       "comment": "Listed with other Project Keys and instructions for verifying key fingerprints: Rocky Linux 8 (Infrastructure)",
-      "url": "https://web.archive.org/web/20240331063950/https://rockylinux.org/keys/",
+      "url": ["https://github.com/rocky-linux/rockylinux.org/blob/develop/resources/gpg-key-info.md", "https://web.archive.org/web/20240331063950/https://rockylinux.org/keys/", "https://rockylinux.org/resources/gpg-key-info", "https://rockylinux.org/keys"],
       "type": "role"
     }
   ],


### PR DESCRIPTION
GPG Key Info page was reportedly removed unintentionally during site revamp. Commit tracks URLs that are either immediately and/or ultimately will become available at https://rockylinux.org/keys

See also:
- https://github.com/rocky-linux/rockylinux.org/issues/128
- https://github.com/rocky-linux/rockylinux.org/pull/129