### PR TITLE
Readme: Clarifications and Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,29 @@
 # Identity Assertion Registry
 [![Registry Validation](https://img.shields.io/github/actions/workflow/status/mattborja/sig3/registry-validate.yml?style=for-the-badge&labelColor=333333&color=007ec6&logo=github&logoColor=ffffff&label=Registry+Validation)](https://github.com/mattborja/sig3/actions/workflows/registry-validate.yml)
-[![Last Activity](https://img.shields.io/github/last-commit/mattborja/sig3?style=for-the-badge&labelColor=333333&color=007ec6&logo=github&logoColor=ffffff&label=Last+Activity)](https://github.com/mattborja/sig3/commits)
+[![Last Activity](https://img.shields.io/github/last-commit/mattborja/sig3?style=for-the-badge&labelColor=333333&color=007ec6&logo=github&logoColor=ffffff&label=Last+Activity)](https://github.com/mattborja/sig3/commit/)
 [![Milestone Progress](https://img.shields.io/github/milestones/progress/mattborja/sig3/1?style=for-the-badge&labelColor=333333&color=007ec6&logo=github&logoColor=ffffff&label=Milestone+Progress)](https://github.com/mattborja/sig3/milestones)
 
 ## Purpose
 To support critical infrastructure needs with an auditable and authoritative registry of digital identify proofs in accordance with industry guidelines and recommendations.
 
+## Scope
+The below tables acknowledge important objectives in this space, while also clarifying which are considered to be **in-scope** vs. **out-of-scope** based on a number of factors, including but not limited to time, effort, resource availability, etc.
+
+| In-Scope Objectives |
+|:---|
+| To resolve a claimed identity (e.g., the name on a GPG key) to a single, unique identity (e.g., person, CI/CD pipeline, organization, etc.) within the context of the population of users the Credential Service Provider (CSP) serves (e.g., infrastructure management, supply chain security engineers, certifying bodies, business-to-business identity managers, etc.). |
+| To validate that all supplied evidence is correct and genuine (e.g., not counterfeit or misappropriated). |
+| To validate that the claimed identity exists in the real world. |
+| To verify that the claimed identity is associated with either: a) the real person supplying the identity evidence, or b) the real person on behalf of which the identity evidence is being provided. |
+
+| Out-of-Scope Objectives | Workaround |
+|:---|:---|
+| Owner verification of the email address listed with the claimed identity | Request key owner to send a *clearsigned* message from email address listed on the key using the same key (see also [/REFS.md#gpg-signature](/REFS.md#gpg-signature)) |
+
 ## Standards
 The following resources are considered applicable and relevant to the orientation and goals of this project:
 - [Digital Identity Guidelines (NIST SP 800-63A)](https://pages.nist.gov/800-63-3/sp800-63a.html)
 - [Key validity and owner trust (GnuPG)](https://www.gnupg.org/gph/en/manual/x334.html)
-
-### Goals
-As provided in NIST SP 800-63A:
-- To resolve a claimed identity to a single, unique identity within the context of the population of users the CSP serves.
-- To validate that all supplied evidence is correct and genuine (e.g., not counterfeit or misappropriated).
-- To validate that the claimed identity exists in the real world.
-- To verify that the claimed identity is associated with the real person supplying the identity evidence.
 
 ## Getting Started
 1. Familiarize yourself with the resources provided in the Standards section above
@@ -24,7 +31,7 @@ As provided in NIST SP 800-63A:
 3. Review all [contributing policies](/COMPLIANCE.md) in effect on this repository
 4. Create a new pull request to submit evidence for a new or existing digital identity
 
-## Reference
+## Additional Reading
 - [Building your web of trust](https://www.gnupg.org/gph/en/manual/x547.html), *The GNU Privacy Guard*
 - [Using trust to validate keys](https://www.gnupg.org/gph/en/manual/x334.html#AEN384), *The GNU Privacy Guard*
 - [Validating authenticity of a key](https://apache.org/info/verification.html#Validating), *The Apache Software Foundation*

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Identity Assertion Registry
 [![Registry Validation](https://img.shields.io/github/actions/workflow/status/mattborja/sig3/registry-validate.yml?style=for-the-badge&labelColor=333333&color=007ec6&logo=github&logoColor=ffffff&label=Registry+Validation)](https://github.com/mattborja/sig3/actions/workflows/registry-validate.yml)
-[![Last Activity](https://img.shields.io/github/last-commit/mattborja/sig3?style=for-the-badge&labelColor=333333&color=007ec6&logo=github&logoColor=ffffff&label=Last+Activity)](https://github.com/mattborja/sig3/commit/)
+[![Last Activity](https://img.shields.io/github/last-commit/mattborja/sig3?style=for-the-badge&labelColor=333333&color=007ec6&logo=github&logoColor=ffffff&label=Last+Activity)](https://github.com/mattborja/sig3/commits/)
 [![Milestone Progress](https://img.shields.io/github/milestones/progress/mattborja/sig3/1?style=for-the-badge&labelColor=333333&color=007ec6&logo=github&logoColor=ffffff&label=Milestone+Progress)](https://github.com/mattborja/sig3/milestones)
 
 ## Purpose

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Identity Assertion Registry
 [![Registry Validation](https://img.shields.io/github/actions/workflow/status/mattborja/sig3/registry-validate.yml?style=for-the-badge&labelColor=333333&color=007ec6&logo=github&logoColor=ffffff&label=Registry+Validation)](https://github.com/mattborja/sig3/actions/workflows/registry-validate.yml)
-[![Last Activity](https://img.shields.io/github/last-commit/mattborja/sig3?style=for-the-badge&labelColor=333333&color=007ec6&logo=github&logoColor=ffffff&label=Last+Activity)](https://github.com/mattborja/sig3/commit/)
+[![Last Activity](https://img.shields.io/github/last-commit/mattborja/sig3?style=for-the-badge&labelColor=333333&color=007ec6&logo=github&logoColor=ffffff&label=Last+Activity)](https://github.com/mattborja/sig3/commits)
 [![Milestone Progress](https://img.shields.io/github/milestones/progress/mattborja/sig3/1?style=for-the-badge&labelColor=333333&color=007ec6&logo=github&logoColor=ffffff&label=Milestone+Progress)](https://github.com/mattborja/sig3/milestones)
 
 ## Purpose

--- a/REFS.md
+++ b/REFS.md
@@ -2,10 +2,13 @@
 A reference list classifying supporting evidence for key validation.
 
 ### GPG Signature
-**Control**: Key  
-**Assurance**: `unknown`
-
-Subject demonstrates possession and exercise of private key.  Expects `artifact` to be populated with a valid PGP signature.
+| Instrument | Expectation |
+|:---|:---|
+| **Control** | Key |
+| **Assurance** | `full` |
+| **Scope** | Subject demonstrates possession and exercise of the private key. |
+| **Requirement** | Subject MUST sign *any message*† using the private key. |
+| **Extensions** | Subject SHOULD use this method to send a *clearsigned* message from the email address listed to any verifier needing to perform additional email verification. |
 
 **Example**:  
 ```json
@@ -16,15 +19,7 @@ Subject demonstrates possession and exercise of private key.  Expects `artifact`
     "type": "key"
 }
 ```
-**Note:** The use of a cryptographically strong random sequence for demonstrating possession and exercise of private key is not precisely necessary. Simply signing the phrase, "Hello, world!" inherits the same assurance by virtue of cryptographic operation and the mandatory presence of the *Signature Creation Time* in the hashed packet ([§5.2.3.4, RFC 4880](https://www.rfc-editor.org/rfc/rfc4880#section-5.2.3.4)), making it trivial for a verifier to assess how recent a signature was produced. It would be more useful for the prover to sign a message containing more pertinent information or claims to the verifier to establish relevance (i.e. asymmetric encryption using the verifier's public GPG key).
-
----
-
-### S/MIME Encrypted and/or Signed Email
-**Control**: Email  
-**Assurance**: `marginal+`
-
-Subject demonstrates possession and exercise of email address and inbox.
+†The use of a cryptographic *nonce* for demonstrating message uniqueness is not strictly necessary due to the presence of the *Signature Creation Time* in the resulting hashed packet ([§5.2.3.4, RFC 4880](https://www.rfc-editor.org/rfc/rfc4880#section-5.2.3.4)).
 
 ---
 

--- a/REFS.md
+++ b/REFS.md
@@ -47,18 +47,25 @@ A reference list classifying supporting evidence for key validation.
 ```
 ---
 
-### Industry License and/or Certification
-**Type**: `role`  
-**Assurance**: `full`
+### Credential Service Provider (CSP)
+> [!NOTE]
+> For an official definition of this reference type, please see corresponding NIST glossary term: [credential service provider (CSP)](https://csrc.nist.gov/glossary/term/credential_service_provider).
 
-Subject has verified identity with independent proctor and demonstrates proficiency and/or license to operate within a specific industry or activity. Expects link to verifiable credential in URL field.
+| Instrument | Expectation |
+|:---|:---|
+| **Type** | `csp` |
+| **Assurance** | `full` |
+| **Scope** | Subject has performed adequate identity verification (SIG3/IAL3) with a trusted entity that issues electronic credentials. |
+| **Requirement** | The *results* of the ID verification process MUST be controlled exclusively by the CSP AND made publicly available the electronic credential with reasonable permanence and immutability. A secure URL (e.g., https://) corresponding to the electronic credential MUST be provided in the ref. |
+| **Extensions** | Valid refs in this space CAN also be used to chart a definitive and decisive path to confirming project involvement or affiliation as evidence of subject matter expertise when made prerequisite to obtaining industry licenses or certifications, as in the case of remote proctored Global Information Assurance Certification (GIAC) exams. |
+
 
 **Example**:  
 ```json
 {
     "date": "2025-01-01",
-    "comment": "Industry `certification requiring strong identity verification during proctored high stakes exam with global information assurance certification (https://www.giac.org/knowledge-base/proctor/)",`
-    "type": "user",
+    "comment": "Industry certification requiring strong identity verification during proctored high stakes exam with global information assurance certification (https://www.giac.org/knowledge-base/proctor/)",`
+    "type": "csp",
     "url": "https://www.credly.com/badges/c0ee1538-53dd-43a0-bf9e-7724e374ff43"
 },
 ```

--- a/REFS.md
+++ b/REFS.md
@@ -8,7 +8,7 @@ A reference list classifying supporting evidence for key validation.
 | **Assurance** | `full` |
 | **Scope** | Subject demonstrates possession and exercise of the private key. |
 | **Requirement** | Subject MUST sign *any message*† using the private key. |
-| **Extensions** | Subject SHOULD use this method to send a *clearsigned* message from the email address listed to any verifier needing to perform additional email verification. |
+| **Extensions** | Verifiers participating in the [key distribution process](https://www.gnupg.org/gph/en/manual/x457.html) SHOULD first be performing email verification using this method to request a message from the email address listed on the public key, *clearsigned* ONLY by the corresponding private key.
 
 **Example**:  
 ```json

--- a/REFS.md
+++ b/REFS.md
@@ -4,7 +4,7 @@ A reference list classifying supporting evidence for key validation.
 ### GPG Signature
 | Instrument | Expectation |
 |:---|:---|
-| **Control** | Key |
+| **Type** | `key` |
 | **Assurance** | `full` |
 | **Scope** | Subject demonstrates possession and exercise of the private key. |
 | **Requirement** | Subject MUST sign *any message*† using the private key. |
@@ -23,25 +23,32 @@ A reference list classifying supporting evidence for key validation.
 
 ---
 
-### Commit History
-**Control**: Role  
-**Assurance**: `full`
-
-Subject demonstrates involvement and association with project. Expects link to commit in URL field.
+### Project or Affiliation
+| Instrument | Expectation |
+|:---|:---|
+| **Type** | `role` |
+| **Assurance** | `marginal`, `full` |
+| **Scope** | Subject demonstrates verifiable project involvement or affiliation. |
+| **Requirement** | Subject MUST show substantial project involvement via multiple factors including but not limited to: signed commits, community involvement, public profiles, affirmation of employment or affiliation, etc. |
+| **Extensions** | URLs to all related work SHOULD be included together as an array of values for the same ref. |
 
 **Example**:  
 ```json
 {
     "date": "2025-03-07",
     "comment": "Self-attestation of own key under GitHub vigilant mode: 1) B5690EEEBB952194 is signing this commit via GitHub web interface, 2) commit author is authenticated as GitHub user @mattborja, AND 2) commit author affirms ownership of this selfsame key (A1C7E813F160A407)",
-    "type": "user",
-    "url": "https://github.com/mattborja/identity/commit/bf06562979a0eb3ef5a9da8d92edb8c7dd886ec7"
+    "type": "role",
+    "url": [
+        "https://github.com/mattborja/identity/commit/bf06562979a0eb3ef5a9da8d92edb8c7dd886ec7",
+        "https://github.com/mattborja/sig3/commit/bf06562979a0eb3ef5a9da8d92edb8c7dd886ec7#diff-7fcdfe7c0b50a3c8d7978401b7d339839221a136e99b5d2c0f90386738f5af65R20",
+        "https://github.com/mattborja.gpg"
+    ]
 }
 ```
 ---
 
 ### Industry License and/or Certification
-**Control**: Role  
+**Type**: `role`  
 **Assurance**: `full`
 
 Subject has verified identity with independent proctor and demonstrates proficiency and/or license to operate within a specific industry or activity. Expects link to verifiable credential in URL field.

--- a/REFS.md
+++ b/REFS.md
@@ -64,7 +64,7 @@ A reference list classifying supporting evidence for key validation.
 ```json
 {
     "date": "2025-01-01",
-    "comment": "Industry certification requiring strong identity verification during proctored high stakes exam with global information assurance certification (https://www.giac.org/knowledge-base/proctor/)",`
+    "comment": "Industry certification requiring strong identity verification during proctored high stakes exam with global information assurance certification (https://www.giac.org/knowledge-base/proctor/)",
     "type": "csp",
     "url": "https://www.credly.com/badges/c0ee1538-53dd-43a0-bf9e-7724e374ff43"
 },

--- a/registry/99BB608E30380C451952D6BBA1C7E813F160A407.json
+++ b/registry/99BB608E30380C451952D6BBA1C7E813F160A407.json
@@ -42,7 +42,7 @@
     {
       "date": "2025-01-01",
       "comment": "Industry certification requiring strong identity verification during proctored high stakes exam with Global Information Assurance Certification (https://www.giac.org/knowledge-base/proctor/)",
-      "type": "user",
+      "type": "csp",
       "url": "https://www.credly.com/badges/c0ee1538-53dd-43a0-bf9e-7724e374ff43"
     },
     {
@@ -53,7 +53,7 @@
     },
     {
       "date": "2025-01-01",
-      "comment": "OrciD profile referenced by Credly profile listing verified email domains, websites, social links, and GPG fingerprints in Keywords section using Uniform Resource Name format: urn:identity:gpg:<fingerprint>",
+      "comment": "ORCiD profile referenced by Credly profile listing verified email domains, websites, social links, and GPG fingerprints in Keywords section using Uniform Resource Name format: urn:identity:gpg:<fingerprint>",
       "type": "user",
       "url": "https://orcid.org/0009-0008-5528-9362"
     }

--- a/schema.json
+++ b/schema.json
@@ -100,9 +100,10 @@
               "key",
               "sig1",
               "sig2",
-              "sig3"
+              "sig3",
+              "csp"
             ],
-            "description": "The type of verification indicated by the evidence provided: project affiliation (role), self-attestation (user), private key use (key), certified by another key holder (sig1, sig2, sig3)"
+            "description": "The type of verification indicated by the evidence provided: project affiliation (role), self-attestation (user), private key use (key), certified by another key holder (sig1, sig2, sig3), certified by a Credential Service Provider (CSP)"
           }
         },
         "required": [


### PR DESCRIPTION
- Updates Last Activity status badge hyperlink to provide a bigger overview of recent commits
- Reassigns Goals to the purpose of clarifying in-scope and out-of-scope objectives for this project (Scope)
- Standardizes REFS.md with instrumentation tables showing appropriate use and expectations for any refs involved in key validation contexts
- Provides guidance for key distributors to perform email verification as an extension of GPG Signatures
- Introduces NIST ref type for representing industry certifications: `csp` ([Credential Service Provider](https://csrc.nist.gov/glossary/term/credential_service_provider))