### PR TITLE
SIG3: Enforcing Key Validation

### DIFF
--- a/SCHEMA.md
+++ b/SCHEMA.md
@@ -12,7 +12,6 @@ The following table summarizes the top-level properties of the schema:
 |---------------|------------------------------------------------------------------|------------------------------------------------------------|
 | `fingerprint` | The GPG key fingerprint associated with the identity assertion. | `259A55407DD6C00299E6607EFFDE55BE73A2D1ED`                |
 | `label`       | The name or title of the key holder.                             | `Jeremy Long`                                              |
-| `validity`    | The trust level of the identity assertion.                      | `full`                                                    |
 | `refs`        | An array of references supporting the identity claim.           | See "Refs" section below.                                  |
 | `tags`        | An array of tags categorizing the identity assertion.           | `["OWASP", "Software Developer"]`                       |
 
@@ -75,7 +74,6 @@ Filename: **/registry/259A55407DD6C00299E6607EFFDE55BE73A2D1ED.json**
 {
   "fingerprint": "259A55407DD6C00299E6607EFFDE55BE73A2D1ED",
   "label": "Jeremy Long",
-  "validity": "full",
   "refs": [
     {
       "date": "2024-10-28",
@@ -100,6 +98,5 @@ Filename: **/registry/259A55407DD6C00299E6607EFFDE55BE73A2D1ED.json**
 
 - Each `fingerprint` must be unique within the registry. The schema enforces a strict limitation of **one JSON file per fingerprint** being attested. This ensures that every GPG key fingerprint is represented by exactly one identity assertion, preventing duplication and maintaining consistency across the registry. When updating or modifying an assertion, the existing JSON file for the relevant fingerprint must be replaced or updated.
 - **`fingerprint`**: Ensure that the **GPG fingerprint** is presented fully and adheres to the correct pattern (at least 16 alphanumeric characters).
-- **`validity`**: The **validity** status should reflect the level of verification based on the provided references. A `full` validity status should only be assigned if multiple independent sources have verified the identity.
 - **`refs`**: Each reference must be **verifiable** and should link to an **authoritative, accessible source**.
 - **`tags`**: The **tags** field can be used to categorize the keyholder by roles or affiliations (e.g., linking keyholders to specific projects or organizations).

--- a/registry/0675BD19F4FFE3AD0B2D6FEBADA2860895AE3D91.json
+++ b/registry/0675BD19F4FFE3AD0B2D6FEBADA2860895AE3D91.json
@@ -1,7 +1,6 @@
 {
   "fingerprint": "0675BD19F4FFE3AD0B2D6FEBADA2860895AE3D91",
   "label": "Rocky Linux 9 - Beta Key V1/2022 <releng@rockylinux.org>",
-  "validity": "full",
   "sources": [
     {
       "type": "url",

--- a/registry/091A44047C3D8B7A331F5E185489E42BBBE2C108.json
+++ b/registry/091A44047C3D8B7A331F5E185489E42BBBE2C108.json
@@ -1,7 +1,6 @@
 {
   "fingerprint": "091A44047C3D8B7A331F5E185489E42BBBE2C108",
   "label": "Release Engineering <infrastructure@rockylinux.org>",
-  "validity": "full",
   "sources": [
     {
       "type": "url",

--- a/registry/115DF9AEF857853EE8445D0A0727707EA15B79CC.json
+++ b/registry/115DF9AEF857853EE8445D0A0727707EA15B79CC.json
@@ -1,6 +1,5 @@
 {
   "fingerprint": "115DF9AEF857853EE8445D0A0727707EA15B79CC",
-  "validity": "marginal",
   "label": "Fedora CoreOS Signing Key",
   "refs": [
     {

--- a/registry/1302DE60231889FE1EBACADC54678CF75A278D9C.json
+++ b/registry/1302DE60231889FE1EBACADC54678CF75A278D9C.json
@@ -1,7 +1,6 @@
 {
   "fingerprint": "1302DE60231889FE1EBACADC54678CF75A278D9C",
   "label": "Paul Rudy",
-  "validity": "marginal",
   "refs": [
     {
       "date": "2025-03-08",

--- a/registry/21CB256AE16FC54C6E652949702D426D350D275D.json
+++ b/registry/21CB256AE16FC54C6E652949702D426D350D275D.json
@@ -1,7 +1,6 @@
 {
   "fingerprint": "21CB256AE16FC54C6E652949702D426D350D275D",
   "label": "Rocky Enterprise Software Foundation - Release key 2022 <releng@rockylinux.org>",
-  "validity": "full",
   "sources": [
     {
       "type": "url",

--- a/registry/259A55407DD6C00299E6607EFFDE55BE73A2D1ED.json
+++ b/registry/259A55407DD6C00299E6607EFFDE55BE73A2D1ED.json
@@ -1,7 +1,6 @@
 {
   "fingerprint": "259A55407DD6C00299E6607EFFDE55BE73A2D1ED",
   "label": "Jeremy Long",
-  "validity": "none",
   "refs": [
     {
       "date": "2024-10-28",

--- a/registry/4AF4D83EEDDF43DA3C06CB3101483F262A4B3FF0.json
+++ b/registry/4AF4D83EEDDF43DA3C06CB3101483F262A4B3FF0.json
@@ -1,7 +1,6 @@
 {
     "fingerprint": "4AF4D83EEDDF43DA3C06CB3101483F262A4B3FF0",
     "label": "Rod Widdowson",
-    "validity": "full",
     "refs": [
       {
         "date": "2022-04-01",
@@ -20,4 +19,3 @@
       "Shibboleth"
     ]
   }
-  

--- a/registry/5E6D6EAE16C3DA75450B219C9A804E97D7079C77.json
+++ b/registry/5E6D6EAE16C3DA75450B219C9A804E97D7079C77.json
@@ -1,7 +1,6 @@
 {
     "fingerprint": "5E6D6EAE16C3DA75450B219C9A804E97D7079C77",
     "label": "Ian Young",
-    "validity": "full",
     "refs": [
       {
         "date": "2022-04-01",
@@ -122,4 +121,3 @@
       "Shibboleth"
     ]
   }
-  

--- a/registry/6D18FD63708FCCA079B68CCE026691839355EBCA.json
+++ b/registry/6D18FD63708FCCA079B68CCE026691839355EBCA.json
@@ -1,7 +1,6 @@
 {
     "fingerprint": "6D18FD63708FCCA079B68CCE026691839355EBCA",
     "label": "Henri Mikkonen",
-    "validity": "full",
     "refs": [
       {
         "date": "2022-04-01",
@@ -20,4 +19,3 @@
       "Shibboleth"
     ]
   }
-  

--- a/registry/6F71F525282841EEDAF851B42F59B5F99B1BE0B4.json
+++ b/registry/6F71F525282841EEDAF851B42F59B5F99B1BE0B4.json
@@ -1,7 +1,6 @@
 {
   "fingerprint": "6F71F525282841EEDAF851B42F59B5F99B1BE0B4",
   "label": "NodeSource",
-  "validity": "full",
   "refs": [
     {
       "date": "2024-12-14",

--- a/registry/7051C470A929F454CEBE37B715AF5DAC6D745A60.json
+++ b/registry/7051C470A929F454CEBE37B715AF5DAC6D745A60.json
@@ -1,7 +1,6 @@
 {
   "fingerprint": "7051C470A929F454CEBE37B715AF5DAC6D745A60",
   "label": "Release Engineering <infrastructure@rockylinux.org>",
-  "validity": "full",
   "sources": [
     {
       "type": "url",

--- a/registry/843938DF228D22F7B3742BC0D94AA3F0EFE21092.json
+++ b/registry/843938DF228D22F7B3742BC0D94AA3F0EFE21092.json
@@ -1,6 +1,5 @@
 {
   "fingerprint": "843938DF228D22F7B3742BC0D94AA3F0EFE21092",
-  "validity": "full",
   "label": "Ubuntu CD Image Automatic Signing Key (2012) <cdimage@ubuntu.com>",
   "refs": [
     {

--- a/registry/99BB608E30380C451952D6BBA1C7E813F160A407.json
+++ b/registry/99BB608E30380C451952D6BBA1C7E813F160A407.json
@@ -1,7 +1,6 @@
 {
   "fingerprint": "99BB608E30380C451952D6BBA1C7E813F160A407",
   "label": "Matt Borja",
-  "validity": "full",
   "refs": [
     {
       "date": "2024-11-27",

--- a/registry/A1DB793DC23663E7F91475D82B999FA9CE046B1B.json
+++ b/registry/A1DB793DC23663E7F91475D82B999FA9CE046B1B.json
@@ -1,7 +1,6 @@
 {
   "fingerprint": "A1DB793DC23663E7F91475D82B999FA9CE046B1B",
   "label": "Werner Koch (384-bit ECDH key)",
-  "validity": "full",
   "refs": [
     {
       "date": "2024-11-27",

--- a/registry/A490D0F4D311A4153E2BB7CADBB802B258ACD84F.json
+++ b/registry/A490D0F4D311A4153E2BB7CADBB802B258ACD84F.json
@@ -1,6 +1,5 @@
 {
   "fingerprint": "A490D0F4D311A4153E2BB7CADBB802B258ACD84F",
-  "validity": "full",
   "label": "Tails OS Signing Key",
   "refs": [
     {

--- a/registry/B5B5DD332142AD657E8D87AC7D27E610B8A3DC52.json
+++ b/registry/B5B5DD332142AD657E8D87AC7D27E610B8A3DC52.json
@@ -1,7 +1,6 @@
 {
     "fingerprint": "B5B5DD332142AD657E8D87AC7D27E610B8A3DC52",
     "label": "Philip David Smart",
-    "validity": "full",
     "refs": [
       {
         "date": "2022-04-01",
@@ -20,4 +19,3 @@
       "Shibboleth"
     ]
   }
-  

--- a/registry/BFC3D8F20D15F4FD46281D7FAA650F52D6C094FA.json
+++ b/registry/BFC3D8F20D15F4FD46281D7FAA650F52D6C094FA.json
@@ -1,7 +1,6 @@
 {
   "fingerprint": "BFC3D8F20D15F4FD46281D7FAA650F52D6C094FA",
   "label": "Core Infrastructure <infrastructure@rockylinux.org>",
-  "validity": "full",
   "sources": [
     {
       "type": "url",

--- a/registry/C2FE4BD271C139B86C533E461E953E27D4311E58.json
+++ b/registry/C2FE4BD271C139B86C533E461E953E27D4311E58.json
@@ -1,6 +1,5 @@
 {
   "fingerprint": "C2FE4BD271C139B86C533E461E953E27D4311E58",
-  "validity": "full",
   "label": "Chris Lamb",
   "refs": [
     {

--- a/registry/DCAA15007BED9DE690CD9523378B845402277962.json
+++ b/registry/DCAA15007BED9DE690CD9523378B845402277962.json
@@ -1,7 +1,6 @@
 {
     "fingerprint": "DCAA15007BED9DE690CD9523378B845402277962",
     "label": "Scott Cantor",
-    "validity": "full",
     "refs": [
       {
         "date": "2022-04-01",
@@ -26,4 +25,3 @@
       "Shibboleth"
     ]
   }
-  

--- a/registry/F30FF4FC936584574EE3251833688C2EDC08CD38.json
+++ b/registry/F30FF4FC936584574EE3251833688C2EDC08CD38.json
@@ -1,7 +1,6 @@
 {
   "fingerprint": "F30FF4FC936584574EE3251833688C2EDC08CD38",
   "label": "Matt Borja",
-  "validity": "full",
   "refs": [
     {
       "date": "2024-11-27",

--- a/schema.json
+++ b/schema.json
@@ -11,17 +11,6 @@
       "type": "string",
       "description": "The label or name associated with the individual or entity, typically matching the name on the GPG key."
     },
-    "validity": {
-      "type": "string",
-      "enum": [
-        "full",
-        "marginal",
-        "revoked",
-        "none"
-      ],
-      "description": "The validity level of the identity assertion. Indicates how thoroughly the identity has been verified.",
-      "example": "full"
-    },
     "sources": {
       "type": "array",
       "minItems": 1,


### PR DESCRIPTION
**Summary:** This PR introduces an intentional breaking change necessary to support scoring calculation (SIG3CALC) of key validity with variability as required by adopters.

In order to achieve this, the `validity` field must now be removed from the schema in order to correctly enable key verifiers to ultimately decide whether a key is to be trusted in their respective environments.

**Disclaimer.** This PR shall serve as the only historic record of the original key validity levels that were originally proposed for keys that have been added to this registry to date and are now being removed ([5291396](https://github.com/mattborja/sig3/pull/67/commits/52913968deccf16c8cad9f7699bca3f64a900365)).