### PR TITLE
Hotfix: Refactor Node.js CI with reusable workflow

### DIFF
--- a/.github/workflows/registry-validate.yml
+++ b/.github/workflows/registry-validate.yml
@@ -4,6 +4,13 @@ permissions:
   contents: read
 
 on:
+  workflow_call:
+    inputs:
+      artifact_base:
+        description: 'Output directory for registry entries passing validation checks from `npm run build`'
+        default: './dist/'
+        required: true
+        type: string
   pull_request:
     types: [ "opened", "reopened", "synchronize" ]
 
@@ -34,10 +41,3 @@ jobs:
       
       - name: node-build
         run: npm run build
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: registry-dist
-          path: ./dist/
-          compression-level: 9
-          overwrite: true

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -27,15 +27,13 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-      - name: Initialize site root related /dist (displace if exists)
+      - name: Displace root relative /dist if exists
         run: |
           [ -d ./html/dist ] && mv ./html/dist ./.html-dist
-          mkdir -p ./html/dist
 
-      - uses: actions/download-artifact@v4
+      - uses: mattborja/sig3/.github/workflows/registry-validate.yml@1
         with:
-          name: registry-dist
-          path: ./html/dist/
+          artifact_base: ./html/dist/
           
       - name: Configure GH pages
         uses: actions/configure-pages@v5

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ import schema from './schema.json' with { type: 'json' };
 
 const REGISTRY_BASE = './registry';
 const REGISTRY_EXT = '.json';
-const ARTIFACT_BASE = './dist';
+const ARTIFACT_BASE = process.argv[2] || './dist/';
 
 const validator = new Validator(schema);
 


### PR DESCRIPTION
- Configures registry-validate.yml as a reusable GH workflow
- Parameterizes ARTIFACT_BASE both in Node.js CI and across disparate workflows (registry-validate.yml, website.yml)
- Refactors artifact handling with reusable workflow

Note: Refactor will cause same workflow to run twice.