### PR TITLE
Hotfix: Resolve invalid reusable workflow ref

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,7 +29,7 @@ jobs:
 
   build-dist:
     needs: sanitize-dist
-    uses: mattborja/sig3/.github/workflows/registry-validate.yml@1
+    uses: mattborja/sig3/.github/workflows/registry-validate.yml@master
     with:
       artifact_base: ./html/dist/
 


### PR DESCRIPTION
Resolves latest CI error: `failed to fetch workflow: reference to workflow should be either a valid branch, tag, or commit`