### PR TITLE
Hotfix: Fix regressed deploy-html-dist-sanitize

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,17 +64,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - id: deploy-html-dist-sanitize
+        run: |
+          [ -d html/dist ] && mv html/dist .html-dist
+
       - id: deploy-dist-download
         uses: actions/download-artifact@v4
         with:
           name: registry-dist
           path: html/
           pattern: '*.json' # Extracted output filenames sanitized for static web
-
-      - id: deploy-html-dist-sanitize
-        run: |
-          [ -d html/dist ] && mv html/dist .html-dist
-          mv dist/ html/
       
       - id: deploy-gh-pages-setup
         uses: actions/configure-pages@v5
@@ -87,8 +86,8 @@ jobs:
       - id: deploy-gh-pages-deploy
         uses: actions/deploy-pages@v4
       
-      - id: deploy-slsa-build
+      - id: deploy-slsa-attestations
         uses: actions/attest-build-provenance@v2
         with:
-          subject-name: registry-dist.zip
+          subject-name: registry-dist
           subject-digest: sha256:${{ needs.sig3-ci.outputs.artifact_digest }}


### PR DESCRIPTION
- Fixes regressed deploy-html-dist-sanitize failing latest SIG-CI
- Resolves subject-name ref discrepancy between `sig3-ci.build-dist-upload` (actions/upload-artifact@v4) and [renamed] `sig3-cd.deploy-slsa-attestations` (actions/attest-build-provenance@v2)