### PR TITLE
Hotfix: Resolve erroenous exit code failing CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
     steps:
       - id: deploy-html-dist-sanitize
         run: |
-          [ -d html/dist ] && mv html/dist .html-dist
+          [ -d html/dist ] && mv html/dist .html-dist || :
 
       - id: deploy-dist-download
         uses: actions/download-artifact@v4


### PR DESCRIPTION
`deploy-html-dist-sanitize` returns exit code 1 if target directory is not found (but no work is actually needed). Hotfix executes noop (`:`) to coerce exit code 0 under these conditions.