### PR TITLE
Hotfix: GH Pages Artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,20 @@ jobs:
           path: dist/*.json
           name: registry-dist
 
+      - id: build-html-dist
+        run: |
+          [ -d html/dist ] && mv html/dist .html-dist
+          mv dist/ html/
+      
+      - id: build-gh-pages-setup
+        uses: actions/configure-pages@v5
+
+      - id: build-gh-pages-upload
+        uses: actions/upload-pages-artifact@v3
+        with:
+          name: github-pages
+          path: ./html
+
   sig3-cd:
     name: SIG3 CD
     if: ${{ github.ref == 'refs/heads/master' }}
@@ -64,30 +78,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - id: deploy-html-dist-sanitize
-        run: |
-          [ -d html/dist ] && mv html/dist .html-dist || :
-
-      - id: deploy-dist-download
-        uses: actions/download-artifact@v4
-        with:
-          name: registry-dist
-          path: html/
-          pattern: '*.json' # Extracted output filenames sanitized for static web
-      
-      - id: deploy-gh-pages-setup
-        uses: actions/configure-pages@v5
-
-      - id: deploy-gh-pages-upload-html
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: ./html
-          
-      - id: deploy-gh-pages-deploy
-        uses: actions/deploy-pages@v4
-      
       - id: deploy-slsa-attestations
         uses: actions/attest-build-provenance@v2
         with:
           subject-name: registry-dist
           subject-digest: sha256:${{ needs.sig3-ci.outputs.artifact_digest }}
+
+      - id: deploy-gh-pages-deploy
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,3 +86,4 @@ jobs:
 
       - id: deploy-gh-pages-deploy
         uses: actions/deploy-pages@v4
+        artifact_name: github-pages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,4 +86,5 @@ jobs:
 
       - id: deploy-gh-pages-deploy
         uses: actions/deploy-pages@v4
-        artifact_name: github-pages
+        with:
+          artifact_name: github-pages


### PR DESCRIPTION
Attempts to resolve misaligned artifacts used to deploy GH pages with (incorrectly uses provenance artifacts):
- Rearranges order of artifact handling to upload `registry-dist` first before merging in `build-html-dist`
- Assigns explicit artifact names to job steps respectively