### PR TITLE
Hotfix: Replace unsupported RegExp.escape()

### DIFF
--- a/html/assets/js/main.js
+++ b/html/assets/js/main.js
@@ -55,8 +55,8 @@ function jsonHighlight(e){return"string"!=typeof e&&(e=JSON.stringify(e,null,"\t
           if (!q)
             return null;
 
-          const sanitized = q.replace(/\s/g, '');
-          const regex = new RegExp(`${RegExp.escape(sanitized)}`, 'i');
+          const sanitized = q.replace(/[^0-9A-F]/gi, '');
+          const regex = new RegExp(sanitized, 'i');
 
           const found = Object.keys(engine.digests).filter(k => regex.test(k));
 


### PR DESCRIPTION
`RegExp.escape()` has [limited availability](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/escape) and is already broken in other browsers under live testing.

Refactor replaces the need for the missing function with a strict regex prefilter removing any non-hexadecimal characters from the query string.