### PR TITLE
Hotfix: Refactor CI to ship registry.idx.txt to web application

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
 
     outputs:
-      artifact_digest: ${{ steps.build-dist-upload.outputs.artifact-digest }}
+      artifact_digest: ${{ steps.build-provenance-dist.outputs.artifact-digest }}
 
     steps:
       - id: build-dist-checkout
@@ -49,20 +49,24 @@ jobs:
           echo "[build-dist-run] GNUPGHOME: $GNUPGHOME"
 
           npm run build
+
+      - id: build-sha256sums
+        run: |
+          sha256sum dist/*.json > SHA256SUMS.txt
         
-      - id: build-dist-upload
+      - id: build-provenance-dist
         uses: actions/upload-artifact@v4
         with:
           path: |
             dist/*.json
+            SHA256SUMS.txt
           name: registry-dist
 
       - id: build-html-dist
         run: |
           [ -d html/dist ] && mv html/dist .html-dist
           mv dist/ html/
-
-          cd html/ && sha256sum dist/*.json > SHA256SUMS.txt
+          mv registry.idx.txt html/
       
       - id: build-gh-pages-setup
         uses: actions/configure-pages@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,6 @@ jobs:
         run: |
           [ -d html/dist ] && mv html/dist .html-dist
           mv dist/ html/
-          mv registry.idx.txt html/
       
       - id: build-gh-pages-setup
         uses: actions/configure-pages@v5

--- a/html/assets/js/main.js
+++ b/html/assets/js/main.js
@@ -33,7 +33,7 @@ function jsonHighlight(e){return"string"!=typeof e&&(e=JSON.stringify(e,null,"\t
     }
 
     // Optional registry index to enable fast substring searches across all indexed fingerprints
-    fetch('/registry.idx.txt')
+    fetch('/dist/registry.idx.txt')
       .then(res => {
         if (!res.ok)
         {

--- a/index.js
+++ b/index.js
@@ -6,7 +6,6 @@ import schema from './schema.json' with { type: 'json' };
 
 const REGISTRY_BASE = './registry';
 const REGISTRY_EXT = '.json';
-const IDX_BASE = './';
 const ARTIFACT_BASE = process.argv[2] || './dist/';
 const KEYCACHE_BASE = process.argv[3] || './cache/';
 
@@ -60,7 +59,7 @@ fs.readdir(REGISTRY_BASE, (err, files) => {
     if (err)
         throw err;
 
-    const IDX = fs.createWriteStream(path.join(IDX_BASE, 'registry.idx.txt'));
+    const IDX = fs.createWriteStream(path.join(ARTIFACT_BASE, 'registry.idx.txt'));
 
     files.forEach(baseFilename => {
         const inFilename = path.join(REGISTRY_BASE, baseFilename);


### PR DESCRIPTION
- Ensures registry.idx.txt is included in dist/ output to web application
- Separates SHA256SUMS.txt to software provenance