### PR TITLE
Feature: Load valid FPR requested via location hash

### DIFF
--- a/html/assets/js/main.js
+++ b/html/assets/js/main.js
@@ -239,4 +239,16 @@ function renderKeyDetails(json) {
                 alert(e);
             });
     });
+
+    // Invoke $form.submit() if valid FPR is requested via hash
+    (function (){
+      const FPR_REGEX = /^#fpr=([0-9A-F]+)$/;
+
+      const match = window.location.hash.match(FPR_REGEX);
+      if (!match)
+        return;
+
+      $query.val(match[1]);
+      $form.submit();
+    })();
 })();


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/fcdfaafe-4be6-4a08-84e3-4ec10e836ee2)

Automatically invoke search form if valid FPR is provided via location hash: `#fpr=KEYID`

Useful for hyperlinking evidence details view of key ID in reference material.