### PR TITLE
Key proofs for authorized Node.js release signers (8)

### DIFF
--- a/SCHEMA.md
+++ b/SCHEMA.md
@@ -4,16 +4,19 @@ The included [**schema**](/schema.json) in this repository defines the acceptabl
 > [!NOTE]
 > Use an online schema validator like [JSONSchema.dev](https://jsonschema.dev/) to prepare a schema-valid JSON submission for a new identity assertion!
 
+## Format
+- JSON document should use 2-space identation
+
 ## Fields
 
 The following table summarizes the top-level properties of the schema:
 
 | Key           | Description                                                      | Example Value                                              |
 |---------------|------------------------------------------------------------------|------------------------------------------------------------|
-| `fingerprint` | The GPG key fingerprint associated with the identity assertion. | `259A55407DD6C00299E6607EFFDE55BE73A2D1ED`                |
+| `fingerprint` | The GPG key fingerprint associated with the identity assertion.  | `259A55407DD6C00299E6607EFFDE55BE73A2D1ED`                 |
 | `label`       | The name or title of the key holder.                             | `Jeremy Long`                                              |
-| `refs`        | An array of references supporting the identity claim.           | See "Refs" section below.                                  |
-| `tags`        | An array of tags categorizing the identity assertion.           | `["OWASP", "Software Developer"]`                       |
+| `refs`        | An array of references supporting the identity claim.            | See "Refs" section below.                                  |
+| `tags`        | An array of tags categorizing the identity assertion.            | `["OWASP", "Software Developer", "Username"]`              |
 
 ## Extended Properties
 
@@ -55,13 +58,13 @@ The `refs` property contains an array of reference objects that support the iden
 
 The `tags` property is an array of strings representing categories or roles associated with the identity assertion.
 
-| Key | Description                                       | Example Value               |
-|-----|---------------------------------------------------|-----------------------------|
-| -   | A tag categorizing the identity assertion.        | `"OWASP"`, `"Developer"` |
+| Key | Description                                       | Example Value                          |
+|-----|---------------------------------------------------|----------------------------------------|
+| -   | A tag categorizing the identity assertion.        | `"OWASP"`, `"Developer"`, `"username"` |
 
 **Full Example of `tags` Collection:**
 ```json
-["OWASP", "Software Developer"]
+["OWASP", "Software Developer", "jeremylong"]
 ```
 
 ## JSON Example

--- a/html/index.html
+++ b/html/index.html
@@ -176,7 +176,7 @@
   </div>
 
   <div id="results-modal" class="modal" tabindex="-1">
-    <div class="modal-dialog modal-lg modal-dialog-centered modal-dialog-scrollable">
+    <div class="modal-dialog modal-xl modal-dialog-centered modal-dialog-scrollable">
       <div class="modal-content">
         <div class="modal-header">
           <h5 class="modal-title">Results</h5>

--- a/registry/108F52B48DB57BB0CC439B2997B01419BD92F80A.json
+++ b/registry/108F52B48DB57BB0CC439B2997B01419BD92F80A.json
@@ -1,0 +1,22 @@
+{
+  "fingerprint": "108F52B48DB57BB0CC439B2997B01419BD92F80A",
+  "label": "Ruy Adorno",
+  "sources": [
+    {
+      "type": "hkps",
+      "uri": "hkps://keys.openpgp.org"
+    }
+  ],
+  "refs": [
+    {
+      "date": "2020-08-05",
+      "comment": "Listed as GPG owner authorized to create and sign releases for Node.js",
+      "url": "https://github.com/nodejs/node/commit/96fd6810b697aa0ec9d090c010f25f139f3995c7",
+      "type": "role"
+    }
+  ],
+  "tags": [
+    "Node.js",
+    "ruyadorno"
+  ]
+}

--- a/registry/890C08DB8579162FEE0DF9DB8BEAB4DFCF555EF4.json
+++ b/registry/890C08DB8579162FEE0DF9DB8BEAB4DFCF555EF4.json
@@ -1,0 +1,26 @@
+{
+  "fingerprint": "890C08DB8579162FEE0DF9DB8BEAB4DFCF555EF4",
+  "label": "Rafael Gonzaga",
+  "sources": [
+    {
+      "type": "hkps",
+      "uri": "hkps://keys.openpgp.org"
+    },
+    {
+      "type": "url",
+      "uri": "https://github.com/RafaelGSS.gpg"
+    }
+  ],
+  "refs": [
+    {
+      "date": "2022-05-20",
+      "comment": "Listed as GPG owner authorized to create and sign releases for Node.js",
+      "url": "https://github.com/nodejs/node/commit/fbee0a896c4a42f7ffbf2dc11b2877641a8568f4",
+      "type": "role"
+    }
+  ],
+  "tags": [
+    "Node.js",
+    "RafaelGSS"
+  ]
+}

--- a/registry/8FCCA13FEF1D0C2E91008E09770F7A9A5AE15600.json
+++ b/registry/8FCCA13FEF1D0C2E91008E09770F7A9A5AE15600.json
@@ -1,0 +1,26 @@
+{
+  "fingerprint": "8FCCA13FEF1D0C2E91008E09770F7A9A5AE15600",
+  "label": "Michaël Zasso",
+  "sources": [
+    {
+      "type": "hkps",
+      "uri": "hkps://keys.openpgp.org"
+    },
+    {
+      "type": "url",
+      "uri": "https://github.com/targos.gpg"
+    }
+  ],
+  "refs": [
+    {
+      "date": "2018-06-08",
+      "comment": "Listed as GPG owner authorized to create and sign releases for Node.js",
+      "url": "https://github.com/nodejs/node/commit/55e597d30658d34388eaeb2248b87ad76b338dff",
+      "type": "role"
+    }
+  ],
+  "tags": [
+    "Node.js",
+    "targos"
+  ]
+}

--- a/registry/A363A499291CBBC940DD62E41F10027AF002F8B0.json
+++ b/registry/A363A499291CBBC940DD62E41F10027AF002F8B0.json
@@ -1,0 +1,26 @@
+{
+  "fingerprint": "A363A499291CBBC940DD62E41F10027AF002F8B0",
+  "label": "Ulises Gascón",
+  "sources": [
+    {
+      "type": "hkps",
+      "uri": "hkps://keys.openpgp.org"
+    },
+    {
+      "type": "url",
+      "uri": "https://github.com/UlisesGascon.gpg"
+    }
+  ],
+  "refs": [
+    {
+      "date": "2023-09-07",
+      "comment": "Listed as GPG owner authorized to create and sign releases for Node.js",
+      "url": "https://github.com/nodejs/node/commit/b3c4f663287ffbe4c473ba5e194b0c9d4e4936f8",
+      "type": "role"
+    }
+  ],
+  "tags": [
+    "Node.js",
+    "UlisesGascon"
+  ]
+}

--- a/registry/C0D6248439F1D5604AAFFB4021D900FFDB233756.json
+++ b/registry/C0D6248439F1D5604AAFFB4021D900FFDB233756.json
@@ -1,0 +1,26 @@
+{
+  "fingerprint": "C0D6248439F1D5604AAFFB4021D900FFDB233756",
+  "label": "Antoine du Hamel",
+  "sources": [
+    {
+      "type": "hkps",
+      "uri": "hkps://keys.openpgp.org"
+    },
+    {
+      "type": "url",
+      "uri": "https://github.com/aduh95.gpg"
+    }
+  ],
+  "refs": [
+    {
+      "date": "2024-10-10",
+      "comment": "Listed as GPG owner authorized to create and sign releases for Node.js",
+      "url": "https://github.com/nodejs/node/commit/d62075566125455dafa2e84cd41373676cb7e158",
+      "type": "role"
+    }
+  ],
+  "tags": [
+    "Node.js",
+    "aduh95"
+  ]
+}

--- a/registry/C82FA3AE1CBEDC6BE46B9360C43CEC45C17AB93C.json
+++ b/registry/C82FA3AE1CBEDC6BE46B9360C43CEC45C17AB93C.json
@@ -1,0 +1,26 @@
+{
+  "fingerprint": "C82FA3AE1CBEDC6BE46B9360C43CEC45C17AB93C",
+  "label": "Richard Lau",
+  "sources": [
+    {
+      "type": "hkps",
+      "uri": "hkps://keys.openpgp.org"
+    },
+    {
+      "type": "url",
+      "uri": "https://github.com/richardlau.gpg"
+    }
+  ],
+  "refs": [
+    {
+      "date": "2020-07-20",
+      "comment": "Listed as GPG owner authorized to create and sign releases for Node.js",
+      "url": "https://github.com/nodejs/node/commit/1b6565b13c0eaa96416f09972acf89a6d8e18cfd",
+      "type": "role"
+    }
+  ],
+  "tags": [
+    "Node.js",
+    "richardlau"
+  ]
+}

--- a/registry/CC68F5A3106FF448322E48ED27F5E38D5B0A215F.json
+++ b/registry/CC68F5A3106FF448322E48ED27F5E38D5B0A215F.json
@@ -1,0 +1,26 @@
+{
+  "fingerprint": "CC68F5A3106FF448322E48ED27F5E38D5B0A215F",
+  "label": "Marco Ippolito",
+  "sources": [
+    {
+      "type": "hkps",
+      "uri": "hkps://keys.openpgp.org"
+    },
+    {
+      "type": "url",
+      "uri": "https://github.com/marco-ippolito.gpg"
+    }
+  ],
+  "refs": [
+    {
+      "date": "2024-03-31",
+      "comment": "Listed as GPG owner authorized to create and sign releases for Node.js",
+      "url": "https://github.com/nodejs/node/commit/fd55458770b88d9a448c724ab6df605006d7d864",
+      "type": "role"
+    }
+  ],
+  "tags": [
+    "Node.js",
+    "marco-ippolito"
+  ]
+}

--- a/registry/DD792F5973C6DE52C432CBDAC77ABFA00DDBF2B7.json
+++ b/registry/DD792F5973C6DE52C432CBDAC77ABFA00DDBF2B7.json
@@ -1,0 +1,28 @@
+{
+  "fingerprint": "DD792F5973C6DE52C432CBDAC77ABFA00DDBF2B7",
+  "label": "Juan José Arboleda",
+  "sources": [
+    {
+      "type": "hkps",
+      "uri": "hkps://keys.openpgp.org"
+    }
+  ],
+  "refs": [
+    {
+      "date": "2023-03-05",
+      "comment": "Listed as GPG owner authorized to create and sign releases for Node.js",
+      "url": "https://github.com/nodejs/node/commit/0b9cf6fbeccf5c02a59b0908628d3e506ecd2485",
+      "type": "role"
+    },
+    {
+      "date": "2023-03-09",
+      "comment": "Key owner's GitHub account referenced by contributor and technical steering committee member @BethGriggs",
+      "url": "https://github.com/nodejs/release-keys/issues/23#issuecomment-1462936104",
+      "type": "role"
+    }
+  ],
+  "tags": [
+    "Node.js",
+    "juanarbol"
+  ]
+}


### PR DESCRIPTION
Registers authorized signers for Node.js releases:
- C0D6248439F1D5604AAFFB4021D900FFDB233756 (Antoine du Hamel)
- DD792F5973C6DE52C432CBDAC77ABFA00DDBF2B7 (Juan José Arboleda)
- CC68F5A3106FF448322E48ED27F5E38D5B0A215F (Marco Ippolito)
- 8FCCA13FEF1D0C2E91008E09770F7A9A5AE15600 (Michaël Zasso)
- 890C08DB8579162FEE0DF9DB8BEAB4DFCF555EF4 (Rafael Gonzaga)
- C82FA3AE1CBEDC6BE46B9360C43CEC45C17AB93C (Richard Lau)
- 108F52B48DB57BB0CC439B2997B01419BD92F80A (Ruy Adorno)
- A363A499291CBBC940DD62E41F10027AF002F8B0 (Ulises Gascón)

Source: https://github.com/nodejs/node/blame/main/README.md