### PR TITLE
Add key proofs for Chris Lamb (lamby)

### DIFF
--- a/registry/C2FE4BD271C139B86C533E461E953E27D4311E58.json
+++ b/registry/C2FE4BD271C139B86C533E461E953E27D4311E58.json
@@ -17,9 +17,33 @@
     },
     {
       "date": "2024-10-14",
-      "comment": "Debian project leader",
+      "comment": "Named Debian project leader (Wikipedia)",
       "type": "role",
       "url": "https://en.wikipedia.org/wiki/List_of_Debian_project_leaders#Chris_Lamb"
+    },
+    {
+      "date": "2017-04-17",
+      "comment": "Chris Lamb (lamby) elected Debian Project Leader in 2017",
+      "type": "role",
+      "url": "https://www.debian.org/vote/2017/vote_001"
+    },
+    {
+      "date": "2017-04-17",
+      "comment": "Acceptance speech after winning 2017 election as Debian Project Leader (2017)",
+      "type": "role",
+      "url": "https://www.debian.org/vote/2017/platforms/lamby"
+    },
+    {
+      "date": "2017-04-17",
+      "comment": "Chris Lamb (lamby) re-elected Debian Project Leader in 2018",
+      "type": "role",
+      "url": "https://www.debian.org/vote/2018/vote_001"
+    },
+    {
+      "date": "2025-07-12",
+      "comment": "Valid signature posted to public mailing list in security update: [SECURITY] [DLA 4240-1] redis security update",
+      "url": "https://lists.debian.org/debian-lts-announce/2025/07/msg00003.html",
+      "role": "key"
     }
   ],
   "tags": [


### PR DESCRIPTION
- Elected as Debian Project Leader (2017, 2018)
- Acceptance speech
- Valid signature bearing fingerprint
