### PR TITLE
Add signing keys for Coreboot.org

### DIFF
--- a/generate.js
+++ b/generate.js
@@ -1,0 +1,33 @@
+// Usage: node ./generate fpr label signatureUrl binaryUrl 
+const fingerprint = process.argv[2] ?? "";
+const label = process.argv[3] ?? "";
+const dateToday = (new Date).toISOString().split('T')[0];
+const signatureUrl = process.argv[4] ?? "https://domain.tld/path/to/file.ext.sig";
+const binaryUrl = process.argv[5] ?? "https://domain.tld/path/to/file.ext";
+const tagsCsv = (process.argv[6] ?? "").split(",").filter(e => !!e);
+
+const tpl = 
+{
+  "fingerprint": fingerprint,
+  "label": label,
+  "sources": [
+    {
+      "type": "hkps",
+      "uri": "hkps://keyserver.ubuntu.com"
+    }
+  ],
+  "refs": [
+    {
+      "date": dateToday,
+      "comment": "Valid GPG signature bearing public key fingerprint",
+      "url": [
+        signatureUrl,
+        binaryUrl
+      ],
+      "type": "key"
+    }
+  ],
+  "tags": tagsCsv
+}
+
+console.log(JSON.stringify(tpl, null, 2));

--- a/registry/1504DB83B93905F5160EB3FD86EB211649573F59.json
+++ b/registry/1504DB83B93905F5160EB3FD86EB211649573F59.json
@@ -1,0 +1,21 @@
+{
+  "fingerprint": "1504DB83B93905F5160EB3FD86EB211649573F59",
+  "label": "Jason Glenesk (coreboot developer) <Jason.Glenesk@gmail.com>",
+  "sources": [
+    {
+      "type": "hkps",
+      "uri": "hkps://keyserver.ubuntu.com"
+    }
+  ],
+  "refs": [
+    {
+      "date": "2025-08-21",
+      "comment": "Listed fingerprint on downloads page",
+      "url": "https://coreboot.org/downloads.html",
+      "type": "role"
+    }
+  ],
+  "tags": [
+    "coreboot"
+  ]
+}

--- a/registry/574CE6F6855CFDEB7D368E9D19796C2B3E4F7DF7.json
+++ b/registry/574CE6F6855CFDEB7D368E9D19796C2B3E4F7DF7.json
@@ -1,0 +1,30 @@
+{
+  "fingerprint": "574CE6F6855CFDEB7D368E9D19796C2B3E4F7DF7",
+  "label": "Martin Roth (coreboot developer) <martin@coreboot.org>",
+  "sources": [
+    {
+      "type": "hkps",
+      "uri": "hkps://keyserver.ubuntu.com"
+    }
+  ],
+  "refs": [
+    {
+      "date": "2025-08-21",
+      "comment": "Valid GPG signature bearing public key fingerprint",
+      "url": [
+        "https://coreboot.org/releases/coreboot-25.06.tar.xz.sig",
+        "https://coreboot.org/releases/coreboot-25.06.tar.xz"
+      ],
+      "type": "key"
+    },
+    {
+      "date": "2025-08-21",
+      "comment": "Listed fingerprint on downloads page",
+      "url": "https://coreboot.org/downloads.html",
+      "type": "role"
+    }
+  ],
+  "tags": [
+    "coreboot"
+  ]
+}

--- a/registry/7642F206B20B77DAEB5B611A53C88CBFBC4F65F3.json
+++ b/registry/7642F206B20B77DAEB5B611A53C88CBFBC4F65F3.json
@@ -1,0 +1,21 @@
+{
+  "fingerprint": "7642F206B20B77DAEB5B611A53C88CBFBC4F65F3",
+  "label": "Angel Pons <th3fanbus@gmail.com>",
+  "sources": [
+    {
+      "type": "hkps",
+      "uri": "hkps://keyserver.ubuntu.com"
+    }
+  ],
+  "refs": [
+    {
+      "date": "2025-08-21",
+      "comment": "Listed fingerprint on downloads page",
+      "url": "https://coreboot.org/downloads.html",
+      "type": "role"
+    }
+  ],
+  "tags": [
+    "coreboot"
+  ]
+}

--- a/registry/C75AAA4E5C9DB017C1DC6EDBDB1B0EC29202D874.json
+++ b/registry/C75AAA4E5C9DB017C1DC6EDBDB1B0EC29202D874.json
@@ -1,0 +1,21 @@
+{
+  "fingerprint": "C75AAA4E5C9DB017C1DC6EDBDB1B0EC29202D874",
+  "label": "Matt DeVillier <matt.devillier@gmail.com>",
+  "sources": [
+    {
+      "type": "hkps",
+      "uri": "hkps://keyserver.ubuntu.com"
+    }
+  ],
+  "refs": [
+    {
+      "date": "2025-08-21",
+      "comment": "Listed fingerprint on downloads page",
+      "url": "https://coreboot.org/downloads.html",
+      "type": "role"
+    }
+  ],
+  "tags": [
+    "coreboot"
+  ]
+}


### PR DESCRIPTION
Related keys included in this change set:
- 1504DB83B93905F5160EB3FD86EB211649573F59
- 574CE6F6855CFDEB7D368E9D19796C2B3E4F7DF7
- 7642F206B20B77DAEB5B611A53C88CBFBC4F65F3
- C75AAA4E5C9DB017C1DC6EDBDB1B0EC29202D874

Recommend follow up for bolstering with additional key proofs.
