### PR TITLE
Add signing key for GPGTools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 dist/
 cache/
+artifacts/
+
 SHA256SUMS.txt
 *.idx*
 

--- a/generate.js
+++ b/generate.js
@@ -1,10 +1,11 @@
-// Usage: node ./generate fpr label signatureUrl binaryUrl 
+// Usage: node ./generate fpr label signatureUrl binaryUrl tags keyserver
 const fingerprint = process.argv[2] ?? "";
 const label = process.argv[3] ?? "";
 const dateToday = (new Date).toISOString().split('T')[0];
 const signatureUrl = process.argv[4] ?? "https://domain.tld/path/to/file.ext.sig";
 const binaryUrl = process.argv[5] ?? "https://domain.tld/path/to/file.ext";
 const tagsCsv = (process.argv[6] ?? "").split(",").filter(e => !!e);
+const keyserver = process.argv[4] ?? "hkps://keyserver.ubuntu.com";
 
 const tpl = 
 {
@@ -13,7 +14,7 @@ const tpl =
   "sources": [
     {
       "type": "hkps",
-      "uri": "hkps://keyserver.ubuntu.com"
+      "uri": keyserver
     }
   ],
   "refs": [

--- a/registry/85E38F69046B44C1EC9FB07B76D78F0500D026C4
+++ b/registry/85E38F69046B44C1EC9FB07B76D78F0500D026C4
@@ -23,19 +23,19 @@
     },
     {
       "date": "2016-12-30",
-      "comment": "Forum post from support staff (Luke Le, 1407470) bearing signature and primary key fingerprint",
+      "comment": "Forum post from developer (Luke Le, #1407470) bearing signature and primary key fingerprint",
       "url": "https://gpgtools.tenderapp.com/discussions/beta/1244-first-beta-of-gpgmail-for-macos-sierra-out-now",
       "type": "key"
     },
     {
       "date": "2025-08-12",
-      "comment": "Forum system attributing role of SUPPORT STAFF to Luke Le (1407470)",
+      "comment": "Forum system attributing role of SUPPORT STAFF to Luke Le (#1407470)",
       "url": "https://gpgtools.tenderapp.com/discussions/feedback/18587-how-to-enter-license-key-from-the-command-line",
       "type": "role"
     },
     {
       "date": "2025-08-18",
-      "comment": "Forum activity of support staff member Luke Le (1407470)",
+      "comment": "Forum activity of developer Luke Le (#1407470)",
       "url": "https://gpgtools.tenderapp.com/users/1407470",
       "type": "role"
     },

--- a/registry/85E38F69046B44C1EC9FB07B76D78F0500D026C4
+++ b/registry/85E38F69046B44C1EC9FB07B76D78F0500D026C4
@@ -1,0 +1,52 @@
+{
+  "fingerprint": "85E38F69046B44C1EC9FB07B76D78F0500D026C4",
+  "label": "GPGTools",
+  "sources": [
+    {
+      "type": "hkps",
+      "uri": "hkps://keys.openpgp.org"
+    },
+    {
+      "type": "url",
+      "uri": "https://gpgtools.org/GPGTools-00D026C4.asc"
+    }
+  ],
+  "refs": [
+    {
+      "date": "2023-07-21",
+      "comment": "Valid GPG signature bearing public key fingerprint",
+      "url": [
+        "https://releases.gpgtools.com/GPG_Suite-2023.3.dmg.sig",
+        "https://releases.gpgtools.com/GPG_Suite-2023.3.dmg"
+      ],
+      "type": "key"
+    },
+    {
+      "date": "2016-12-30",
+      "comment": "Forum post from support staff (Luke Le, 1407470) bearing signature and primary key fingerprint",
+      "url": "https://gpgtools.tenderapp.com/discussions/beta/1244-first-beta-of-gpgmail-for-macos-sierra-out-now",
+      "type": "key"
+    },
+    {
+      "date": "2025-08-12",
+      "comment": "Forum system attributing role of SUPPORT STAFF to Luke Le (1407470)",
+      "url": "https://gpgtools.tenderapp.com/discussions/feedback/18587-how-to-enter-license-key-from-the-command-line",
+      "type": "role"
+    },
+    {
+      "date": "2025-08-18",
+      "comment": "Forum activity of support staff member Luke Le (1407470)",
+      "url": "https://gpgtools.tenderapp.com/users/1407470",
+      "type": "role"
+    },
+    {
+      "date": "2025-08-23",
+      "comment": "Instructions for downloading and verifying releases with link to public key bearing primary key fingerprint",
+      "url": "https://gpgtools.tenderapp.com/kb/how-to/how-to-verify-the-downloaded-gpg-suite",
+      "type": "role"
+    }
+  ],
+  "tags": [
+    "gpgtools"
+  ]
+}

--- a/registry/8C371C40B31DA620815E01A9779FEB1392CBBADF.json
+++ b/registry/8C371C40B31DA620815E01A9779FEB1392CBBADF.json
@@ -1,0 +1,33 @@
+{
+  "fingerprint": "8C371C40B31DA620815E01A9779FEB1392CBBADF",
+  "label": "Steve (GPGTools)",
+  "sources": [
+    {
+      "type": "hkps",
+      "uri": "hkps://keys.openpgp.org"
+    }
+  ],
+  "refs": [
+    {
+      "date": "2023-09-06",
+      "comment": "Knowledge Base article presenting primary key fingerprint from working keyserver in screenshots",
+      "url": "https://gpgtools.tenderapp.com/kb/gpg-keychain-faq/upload-and-verify-your-public-key",
+      "type": "role"
+    },
+    {
+      "date": "2019-06-19",
+      "comment": "Forum post showing system attribution of role SUPPORT STAFF to Steve (#1407340)",
+      "url": "https://gpgtools.tenderapp.com/discussions/problems/100465#comment_63661462",
+      "type": "role"
+    },
+    {
+      "date": "2013-10-30",
+      "comment": "Forum post from suport staff Steve (#1407340) claiming primary key fingerprint",
+      "url": "https://gpgtools.tenderapp.com/discussions/problems/12584#comment_29713775",
+      "type": "role"
+    }
+  ],
+  "tags": [
+    "gpgtools"
+  ]
+}


### PR DESCRIPTION
Primary key: `85E38F69046B44C1EC9FB07B76D78F0500D026C4`

Related resources and identities:
- https://gpgtools.tenderapp.com/kb/how-to/how-to-verify-the-downloaded-gpg-suite
- https://gpgtools.tenderapp.com/kb/how-to/trusting-keys-and-why-this-signature-is-not-to-be-trusted
- Steve (`8C371C40B31DA620815E01A9779FEB1392CBBADF`), Support Staff
- Luke Le, Developer

Note: Additional verifications for related identities (Luke Le, Steve) should be included in this PR before merging.