### PR TITLE
Add signing keys for Debian

### DIFF
--- a/generate.js
+++ b/generate.js
@@ -5,7 +5,7 @@ const dateToday = (new Date).toISOString().split('T')[0];
 const signatureUrl = process.argv[4] ?? "https://domain.tld/path/to/file.ext.sig";
 const binaryUrl = process.argv[5] ?? "https://domain.tld/path/to/file.ext";
 const tagsCsv = (process.argv[6] ?? "").split(",").filter(e => !!e);
-const keyserver = process.argv[4] ?? "hkps://keyserver.ubuntu.com";
+const keyserver = process.argv[7] ?? "hkps://keyserver.ubuntu.com";
 
 const tpl = 
 {

--- a/registry/10460DAD76165AD81FBC0CE9988021A964E6EA7D.json
+++ b/registry/10460DAD76165AD81FBC0CE9988021A964E6EA7D.json
@@ -1,0 +1,25 @@
+{
+  "fingerprint": "10460DAD76165AD81FBC0CE9988021A964E6EA7D",
+  "label": "Debian CD signing key",
+  "sources": [
+    {
+      "type": "hkps",
+      "uri": "hkps://keyring.debian.org:443"
+    },
+    {
+      "type": "url",
+      "uri": "https://www.debian.org/CD/key-988021A964E6EA7D.txt"
+    }
+  ],
+  "refs": [
+    {
+      "date": "2025-04-04",
+      "comment": "Listed primary key fingerprint on official documentation page for verifying authenticity of Debian images",
+      "url": "https://www.debian.org/CD/verify",
+      "type": "role"
+    }
+  ],
+  "tags": [
+    "debian"
+  ]
+}

--- a/registry/DF9B9C49EAA9298432589D76DA87E80D6294BE9B.json
+++ b/registry/DF9B9C49EAA9298432589D76DA87E80D6294BE9B.json
@@ -1,0 +1,34 @@
+{
+  "fingerprint": "DF9B9C49EAA9298432589D76DA87E80D6294BE9B",
+  "label": "Debian CD signing key",
+  "sources": [
+    {
+      "type": "hkps",
+      "uri": "hkps://keyring.debian.org:443"
+    },
+    {
+      "type": "url",
+      "uri": "https://www.debian.org/CD/key-DA87E80D6294BE9B.txt"
+    }
+  ],
+  "refs": [
+    {
+      "date": "2025-08-09",
+      "comment": "Valid GPG signature on signed checksums file bearing public key fingerprint",
+      "url": [
+        "https://cdimage.debian.org/debian-cd/current/armhf/iso-cd/SHA512SUMS.sign",
+        "https://cdimage.debian.org/debian-cd/current/armhf/iso-cd/SHA512SUMS"
+      ],
+      "type": "key"
+    },
+    {
+      "date": "2025-04-04",
+      "comment": "Listed primary key fingerprint on official documentation page for verifying authenticity of Debian images",
+      "url": "https://www.debian.org/CD/verify",
+      "type": "role"
+    }
+  ],
+  "tags": [
+    "debian"
+  ]
+}

--- a/registry/F41D30342F3546695F65C66942468F4009EA8AC3.json
+++ b/registry/F41D30342F3546695F65C66942468F4009EA8AC3.json
@@ -1,0 +1,34 @@
+{
+  "fingerprint": "F41D30342F3546695F65C66942468F4009EA8AC3",
+  "label": "Debian Testing CDs Automatic Signing Key",
+  "sources": [
+    {
+      "type": "hkps",
+      "uri": "hkps://keyring.debian.org:443"
+    },
+    {
+      "type": "url",
+      "uri": "https://www.debian.org/CD/key-42468F4009EA8AC3.txt"
+    }
+  ],
+  "refs": [
+    {
+      "date": "2025-08-04",
+      "comment": "Valid GPG signature on signed checksums file bearing public key fingerprint",
+      "url": [
+        "https://cdimage.debian.org/cdimage/weekly-builds/armhf/iso-cd/SHA512SUMS.sign",
+        "https://cdimage.debian.org/cdimage/weekly-builds/armhf/iso-cd/SHA512SUMS"
+      ],
+      "type": "key"
+    },
+    {
+      "date": "2025-04-04",
+      "comment": "Listed primary key fingerprint on official documentation page for verifying authenticity of Debian images",
+      "url": "https://www.debian.org/CD/verify",
+      "type": "role"
+    }
+  ],
+  "tags": [
+    "debian"
+  ]
+}


### PR DESCRIPTION
Source: https://www.debian.org/CD/verify

```
pub   rsa4096/[988021A964E6EA7D](https://www.debian.org/CD/key-988021A964E6EA7D.txt) 2009-10-03
      Key fingerprint = 1046 0DAD 7616 5AD8 1FBC  0CE9 9880 21A9 64E6 EA7D
uid                  Debian CD signing key <debian-cd@lists.debian.org>

pub   rsa4096/[DA87E80D6294BE9B](https://www.debian.org/CD/key-DA87E80D6294BE9B.txt) 2011-01-05 [SC]
      Key fingerprint = DF9B 9C49 EAA9 2984 3258  9D76 DA87 E80D 6294 BE9B
uid                  Debian CD signing key <debian-cd@lists.debian.org>

pub   rsa4096/[42468F4009EA8AC3](https://www.debian.org/CD/key-42468F4009EA8AC3.txt) 2014-04-15 [SC]
      Key fingerprint = F41D 3034 2F35 4669 5F65  C669 4246 8F40 09EA 8AC3
uid                  Debian Testing CDs Automatic Signing Key <debian-cd@lists.debian.org>
```